### PR TITLE
Added filter checklist delay to improve performance

### DIFF
--- a/AdvancedDataGridView/ColumnHeaderCell.cs
+++ b/AdvancedDataGridView/ColumnHeaderCell.cs
@@ -98,6 +98,7 @@ namespace Zuby.ADGV
             IsSortEnabled = true;
             IsFilterEnabled = true;
             IsFilterChecklistEnabled = true;
+            FilterChecklistDelay = 600;
         }
         ~ColumnHeaderCell()
         {
@@ -374,6 +375,15 @@ namespace Zuby.ADGV
             {
                 MenuStrip.DoesTextFilterRemoveNodesOnSearch = value;
             }
+        }
+
+        /// <summary>
+        /// Set the checklist filter delay
+        /// </summary>
+        public int FilterChecklistDelay
+        {
+            get { return MenuStrip.FilterChecklistDelay; }
+            set { MenuStrip.FilterChecklistDelay = value; }
         }
 
         /// <summary>

--- a/AdvancedDataGridView/MenuStrip.cs
+++ b/AdvancedDataGridView/MenuStrip.cs
@@ -78,7 +78,7 @@ namespace Zuby.ADGV
         private string _filterString = null;
         private static Point _resizeStartPoint = new Point(1, 1);
         private Point _resizeEndPoint = new Point(-1, -1);
-        private bool _checkTextFilterChangedEnabled = true;
+        private TextBoxTypeAssistant _checkTextFilterTypeAssistant;
         private bool _checkTextFilterRemoveNodesOnSearch = DefaultCheckTextFilterRemoveNodesOnSearch;
         private int _maxChecklistNodes = DefaultMaxChecklistNodes;
         private bool _filterclick = false;
@@ -145,6 +145,10 @@ namespace Zuby.ADGV
                 sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCtxt;
             }
 
+            // create assistant to delay text box text changed event
+            _checkTextFilterTypeAssistant = new TextBoxTypeAssistant(checkTextFilter);
+            _checkTextFilterTypeAssistant.TextChanged += CheckTextFilter_TextChanged;
+
             //set check filter textbox
             if (DataType == typeof(DateTime) || DataType == typeof(TimeSpan) || DataType == typeof(bool))
                 checkTextFilter.Enabled = false;
@@ -202,9 +206,9 @@ namespace Zuby.ADGV
 
             _startingNodes = new TreeNodeItemSelector[] { };
 
-            _checkTextFilterChangedEnabled = false;
+            _checkTextFilterTypeAssistant.Enabled = false;
             checkTextFilter.Text = "";
-            _checkTextFilterChangedEnabled = true;
+            _checkTextFilterTypeAssistant.Enabled = true;
         }
 
         /// <summary>
@@ -370,6 +374,15 @@ namespace Zuby.ADGV
             }
         }
 
+        /// <summary>
+        /// Set the checklist filter delay
+        /// </summary>
+        public int FilterChecklistDelay
+        {
+            get { return _checkTextFilterTypeAssistant.DelayMilliSeconds; }
+            set { _checkTextFilterTypeAssistant.DelayMilliSeconds = value; }
+        }
+
         #endregion
 
 
@@ -512,9 +525,9 @@ namespace Zuby.ADGV
 
             _filterclick = false;
 
-            _checkTextFilterChangedEnabled = false;
+            _checkTextFilterTypeAssistant.Enabled = false;
             checkTextFilter.Text = "";
-            _checkTextFilterChangedEnabled = true;
+            _checkTextFilterTypeAssistant.Enabled = true;
         }
 
         /// <summary>
@@ -526,9 +539,9 @@ namespace Zuby.ADGV
         /// <param name="_restoreFilter"></param>
         public void Show(Control control, int x, int y, bool _restoreFilter)
         {
-            _checkTextFilterChangedEnabled = false;
+            _checkTextFilterTypeAssistant.Enabled = false;
             checkTextFilter.Text = "";
-            _checkTextFilterChangedEnabled = true;
+            _checkTextFilterTypeAssistant.Enabled = true;
             if (_restoreFilter || _checkTextFilterRemoveNodesOnSearch)
             {
                 //reset the starting nodes
@@ -1630,8 +1643,6 @@ namespace Zuby.ADGV
         /// <param name="e"></param>
         private void CheckTextFilter_TextChanged(object sender, EventArgs e)
         {
-            if (!_checkTextFilterChangedEnabled)
-                return;
             TreeNodeItemSelector allnode = TreeNodeItemSelector.CreateNode(AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVNodeSelectAll.ToString()] + "            ", null, CheckState.Checked, TreeNodeItemSelector.CustomNodeType.SelectAll);
             TreeNodeItemSelector nullnode = TreeNodeItemSelector.CreateNode(AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVNodeSelectEmpty.ToString()] + "               ", null, CheckState.Checked, TreeNodeItemSelector.CustomNodeType.SelectEmpty);
             string[] removednodesText = new string[] { };

--- a/AdvancedDataGridView/MenuStrip.designer.cs
+++ b/AdvancedDataGridView/MenuStrip.designer.cs
@@ -300,7 +300,6 @@ namespace Zuby.ADGV
             this.checkTextFilter.Margin = new System.Windows.Forms.Padding(0);
             this.checkTextFilter.Size = checkTextFilterControlHost.Size;
             this.checkTextFilter.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.checkTextFilter.TextChanged += new System.EventHandler(CheckTextFilter_TextChanged);
             //
             // checkFilterListButtonsPanel
             //

--- a/AdvancedDataGridView/TextBoxTypeAssistant.cs
+++ b/AdvancedDataGridView/TextBoxTypeAssistant.cs
@@ -1,0 +1,91 @@
+﻿#region License
+// Advanced DataGridView
+//
+// Copyright (c), 2014 Davide Gironi <davide.gironi@gmail.com>
+// Original work Copyright (c), 2013 Zuby <zuby@me.com>
+//
+// Please refer to LICENSE file for licensing information.
+#endregion
+
+using System;
+using System.Windows.Forms;
+
+namespace Zuby.ADGV
+{
+    internal class TextBoxTypeAssistant
+    {
+        #region class fields
+
+        private readonly System.Threading.Timer _delayTimer;
+        private bool _enabled = true;
+
+        #endregion
+
+        #region public properties
+
+        /// <summary>
+        /// Get or set the delay.
+        /// </summary>
+        public int DelayMilliSeconds { get; set; }
+
+        /// <summary>
+        /// Enable state of the assistent.
+        /// Setting enabled to false will cancel any ongoing delay.
+        /// </summary>
+        public bool Enabled
+        {
+            get { return _enabled; }
+            set 
+            {   
+                _enabled = value;
+                if(!_enabled)
+                    _delayTimer.Change(System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
+            }
+        }
+
+        #endregion
+
+        #region public events
+
+        public event EventHandler TextChanged;
+
+        #endregion
+
+        #region constructors
+
+        /// <summary>
+        /// TextBoxTypeAssistant constructor
+        /// </summary>
+        /// <param name="textbox"></param>
+        /// <param name="delayMilliSeconds"></param>
+        public TextBoxTypeAssistant(TextBox textbox, int delayMilliSeconds)
+        {
+            DelayMilliSeconds = delayMilliSeconds;
+
+            _delayTimer = new System.Threading.Timer(p =>
+            {
+                textbox.Invoke(
+                    new MethodInvoker(() =>
+                        TextChanged?.Invoke(this, EventArgs.Empty)
+                    )
+                );
+            });
+
+            textbox.TextChanged += (s, e) =>
+            {
+                if(_enabled)
+                    _delayTimer.Change(DelayMilliSeconds, System.Threading.Timeout.Infinite);
+            };
+        }
+
+        /// <summary>
+        /// TextBoxTypeAssistant constructor
+        /// </summary>
+        /// <param name="textbox"></param>
+        public TextBoxTypeAssistant(TextBox textbox)
+            : this(textbox, 600)
+        { }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Hi!
Experienced some performance issues when using the checklist filter on ADGVs with a large number of rows (10 000+) and complex (per row unique) string values in the column. Making 1 search took some second which is no problem. But for every character added to the checklist filter textbox a new search was performed, adding up to an unacceptable time.

Fixed the issue by adding a delay to allow for multiple characters to be typed before the search is performed. For every change of the filter (characters added or removed) the delay is reset. Default delay is 600ms, but is adjustable. 

Sharing it here to be used it if you like it.