### PR TITLE
Fixed bug with checkbox text filter delays

### DIFF
--- a/AdvancedDataGridView/MenuStrip.cs
+++ b/AdvancedDataGridView/MenuStrip.cs
@@ -1715,10 +1715,10 @@ namespace Zuby.ADGV
                 if (_textFilterTextChangedTimer == null)
                 {
                     _textFilterTextChangedTimer = new Timer();
-                    _textFilterTextChangedTimer.Interval = _textFilterTextChangedDelayMs;
                     _textFilterTextChangedTimer.Tick += new EventHandler(this.CheckTextFilterTextChangedTimer_Tick);
                 }
                 _textFilterTextChangedTimer.Stop();
+                _textFilterTextChangedTimer.Interval = _textFilterTextChangedDelayMs;
                 _textFilterTextChangedTimer.Tag = checkTextFilter.Text.ToLower();
                 _textFilterTextChangedTimer.Start();
             }

--- a/AdvancedDataGridViewSample/FormMain.cs
+++ b/AdvancedDataGridViewSample/FormMain.cs
@@ -190,6 +190,7 @@ namespace AdvancedDataGridViewSample
             advancedDataGridView_main.SetFilterCustomEnabled(advancedDataGridView_main.Columns["timespan"], false);
             advancedDataGridView_main.CleanSort(advancedDataGridView_main.Columns["datetime"]);
             advancedDataGridView_main.SetFilterChecklistTextFilterTextChangedDelayNodes(advancedDataGridView_main.Columns["string"], 10);
+            advancedDataGridView_main.SetFilterChecklistTextFilterTextChangedDelayMs(advancedDataGridView_main.Columns["string"], 500);
 
             //memory test
             if (!_memorytest)


### PR DESCRIPTION
Changing the TextFilterTextChangedDelayMs property does not change the delay from the default 300ms.
The reason is the interval of the timer is never updated after timer creation. 