### PR TITLE
MenuStrip data types update OnDataSourceChanged

### DIFF
--- a/AdvancedDataGridView/AdvancedDataGridView.cs
+++ b/AdvancedDataGridView/AdvancedDataGridView.cs
@@ -236,6 +236,12 @@ namespace Zuby.ADGV
             _menuStripToDispose.Clear();
 
             base.OnDataSourceChanged(e);
+
+            foreach (DataGridViewColumn column in Columns)
+            {
+                ColumnHeaderCell cell = column.HeaderCell as ColumnHeaderCell;
+                cell.MenuStrip.ChangeDataType(column.ValueType);
+            }
         }
         #endregion
 

--- a/AdvancedDataGridView/AdvancedDataGridView.cs
+++ b/AdvancedDataGridView/AdvancedDataGridView.cs
@@ -240,7 +240,7 @@ namespace Zuby.ADGV
             foreach (DataGridViewColumn column in Columns)
             {
                 ColumnHeaderCell cell = column.HeaderCell as ColumnHeaderCell;
-                cell.MenuStrip.ChangeDataType(column.ValueType);
+                cell.MenuStrip.SetDataType(column.ValueType);
             }
         }
         #endregion

--- a/AdvancedDataGridView/MenuStrip.cs
+++ b/AdvancedDataGridView/MenuStrip.cs
@@ -207,6 +207,57 @@ namespace Zuby.ADGV
             _textFilterTextChangedTimer.Tick += new EventHandler(this.CheckTextFilterTextChangedTimer_Tick);
         }
 
+        internal void ChangeDataType(Type dataType)
+        {
+            //set type
+            DataType = dataType;
+
+            //set components values
+            if (DataType == typeof(DateTime) || DataType == typeof(TimeSpan))
+            {
+                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
+                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortDateTimeASC.ToString()];
+                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortDateTimeDESC.ToString()];
+                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCnum;
+                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCnum;
+            }
+            else if (DataType == typeof(bool))
+            {
+                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
+                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortBoolASC.ToString()];
+                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortBoolDESC.ToString()];
+                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCbool;
+                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCbool;
+            }
+            else if (DataType == typeof(Int32) || DataType == typeof(Int64) || DataType == typeof(Int16) ||
+                DataType == typeof(UInt32) || DataType == typeof(UInt64) || DataType == typeof(UInt16) ||
+                DataType == typeof(Byte) || DataType == typeof(SByte) || DataType == typeof(Decimal) ||
+                DataType == typeof(Single) || DataType == typeof(Double))
+            {
+                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
+                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortNumASC.ToString()];
+                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortNumDESC.ToString()];
+                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCnum;
+                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCnum;
+            }
+            else
+            {
+                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
+                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortTextASC.ToString()];
+                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortTextDESC.ToString()];
+                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCtxt;
+                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCtxt;
+            }
+
+            //set check filter textbox
+            if (DataType == typeof(DateTime) || DataType == typeof(TimeSpan) || DataType == typeof(bool))
+                checkTextFilter.Enabled = false;
+
+            //set default compoents
+            customFilterLastFiltersListMenuItem.Enabled = DataType != typeof(bool);
+            customFilterLastFiltersListMenuItem.Checked = ActiveFilterType == FilterType.Custom;
+        }
+
         /// <summary>
         /// Closed event
         /// </summary>

--- a/AdvancedDataGridView/MenuStrip.cs
+++ b/AdvancedDataGridView/MenuStrip.cs
@@ -123,48 +123,7 @@ namespace Zuby.ADGV
             button_undofilter.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVButtonUndofilter.ToString()];
 
             //set type
-            DataType = dataType;
-
-            //set components values
-            if (DataType == typeof(DateTime) || DataType == typeof(TimeSpan))
-            {
-                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
-                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortDateTimeASC.ToString()];
-                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortDateTimeDESC.ToString()];
-                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCnum;
-                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCnum;
-            }
-            else if (DataType == typeof(bool))
-            {
-                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
-                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortBoolASC.ToString()];
-                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortBoolDESC.ToString()];
-                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCbool;
-                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCbool;
-            }
-            else if (DataType == typeof(Int32) || DataType == typeof(Int64) || DataType == typeof(Int16) ||
-                DataType == typeof(UInt32) || DataType == typeof(UInt64) || DataType == typeof(UInt16) ||
-                DataType == typeof(Byte) || DataType == typeof(SByte) || DataType == typeof(Decimal) ||
-                DataType == typeof(Single) || DataType == typeof(Double))
-            {
-                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
-                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortNumASC.ToString()];
-                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortNumDESC.ToString()];
-                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCnum;
-                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCnum;
-            }
-            else
-            {
-                customFilterLastFiltersListMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVCustomFilter.ToString()];
-                sortASCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortTextASC.ToString()];
-                sortDESCMenuItem.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVSortTextDESC.ToString()];
-                sortASCMenuItem.Image = Properties.Resources.MenuStrip_OrderASCtxt;
-                sortDESCMenuItem.Image = Properties.Resources.MenuStrip_OrderDESCtxt;
-            }
-
-            //set check filter textbox
-            if (DataType == typeof(DateTime) || DataType == typeof(TimeSpan) || DataType == typeof(bool))
-                checkTextFilter.Enabled = false;
+            SetDataType(dataType);
 
             //set default NOT IN logic
             IsFilterNOTINLogicEnabled = false;
@@ -174,10 +133,6 @@ namespace Zuby.ADGV
             IsFilterEnabled = true;
             IsFilterChecklistEnabled = true;
             IsFilterDateAndTimeEnabled = true;
-
-            //set default compoents
-            customFilterLastFiltersListMenuItem.Enabled = DataType != typeof(bool);
-            customFilterLastFiltersListMenuItem.Checked = ActiveFilterType == FilterType.Custom;
 
             //resize before hitting ResizeBox so the grip works correctly
             float scalingfactor = GetScalingFactor();
@@ -207,9 +162,8 @@ namespace Zuby.ADGV
             _textFilterTextChangedTimer.Tick += new EventHandler(this.CheckTextFilterTextChangedTimer_Tick);
         }
 
-        internal void ChangeDataType(Type dataType)
+        internal void SetDataType(Type dataType)
         {
-            //set type
             DataType = dataType;
 
             //set components values


### PR DESCRIPTION
The data type for MenuStrips is now updated in the grid's OnDataSourceChanged event. Similar to how that event checks to see what MenuStrips need to be disposed before triggering the base event, this change adds a loop to change the data DataType based on the columns' current ValueTypes post-event.

I believe this addresses issue #95 and  issue #10.