### PR TITLE
Sort also enabled on dataview & datatable

### DIFF
--- a/AdvancedDataGridView/AdvancedDataGridView.cs
+++ b/AdvancedDataGridView/AdvancedDataGridView.cs
@@ -786,11 +786,21 @@ namespace Zuby.ADGV
             }
             //sort datasource
             if (sortEventArgs.Cancel == false)
-            {
-                BindingSource datasource = this.DataSource as BindingSource;
-                if (datasource != null)
-                    datasource.Sort = sortEventArgs.SortString;
-            }
+			{
+				if (this.DataSource is BindingSource bindingsource)
+				{
+					bindingsource.Sort = sortEventArgs.SortString;
+				}
+				else if (this.DataSource is DataView dataview)
+				{
+					dataview.Sort = sortEventArgs.SortString;
+				}
+				else if (this.DataSource is DataTable datatable)
+				{
+					if (datatable.DefaultView != null)
+						datatable.DefaultView.Sort = sortEventArgs.SortString;
+				}
+			}
             //invoke SortStringChanged
             if (!_sortStringChangedInvokeBeforeDatasourceUpdate)
             {


### PR DESCRIPTION
Enabled sort for dataviews and datatables as well. Working with datatables I found out that the filtering was working on datatables, while the sorting was not working. So, In the source code I found this piece of code missing. I hope it helps 👍