### PR TITLE
Enable the "not containing" custom filter to treat null values as not containing

### DIFF
--- a/AdvancedDataGridView/AdvancedDataGridView.cs
+++ b/AdvancedDataGridView/AdvancedDataGridView.cs
@@ -617,6 +617,23 @@ namespace Zuby.ADGV
             }
         }
 
+        // <summary>
+        /// Sets whether or not "Not Containing" custom filters will include nulls (i.e. null is also not containing)
+        /// </summary>
+        /// <param name="column"></param>
+        /// <param name="checkNulls"></param>
+        public void SetNotContainingChecksNull(DataGridViewColumn column, bool checkNulls)
+        {
+            if (Columns.Contains(column))
+            {
+                ColumnHeaderCell cell = column.HeaderCell as ColumnHeaderCell;
+                if (cell != null)
+                {
+                    cell.NotContainingChecksNull = checkNulls;
+                }
+            }
+        }
+
         /// <summary>
         /// Set nodes to enable TextChanged delay on filter checklist
         /// </summary>

--- a/AdvancedDataGridView/ColumnHeaderCell.cs
+++ b/AdvancedDataGridView/ColumnHeaderCell.cs
@@ -406,6 +406,18 @@ namespace Zuby.ADGV
             }
         }
 
+        public bool NotContainingChecksNull
+        {
+            get
+            {
+                return MenuStrip.NotContainingChecksNull;
+            }
+            set
+            {
+                MenuStrip.NotContainingChecksNull = value;
+            }
+        }
+
         /// <summary>
         /// Enabled or disable Sort capabilities
         /// </summary>
@@ -515,7 +527,6 @@ namespace Zuby.ADGV
                 MenuStrip.TextFilterTextChangedDelayMs = milliseconds;
             }
         }
-
         #endregion
 
 

--- a/AdvancedDataGridView/FormCustomFilter.cs
+++ b/AdvancedDataGridView/FormCustomFilter.cs
@@ -321,19 +321,19 @@ namespace Zuby.ADGV
                     if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVEquals.ToString()])
                         filterString += "LIKE '" + txt + "'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotEqual.ToString()])
-                        filterString += "NOT LIKE '" + txt + "'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
+                        filterString += "NOT LIKE '" + txt + "'" + (_notContainingChecksNull ? " OR " + column + "IS NULL" : "");
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVBeginsWith.ToString()])
                         filterString += "LIKE '" + txt + "%'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVEndsWith.ToString()])
                         filterString += "LIKE '%" + txt + "'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotBeginWith.ToString()])
-                        filterString += "NOT LIKE '" + txt + "%'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
+                        filterString += "NOT LIKE '" + txt + "%'" + (_notContainingChecksNull ? " OR " + column + "IS NULL" : "");
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotEndWith.ToString()])
-                        filterString += "NOT LIKE '%" + txt + "'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
+                        filterString += "NOT LIKE '%" + txt + "'" + (_notContainingChecksNull ? " OR " + column + "IS NULL" : "");
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVContains.ToString()])
                         filterString += "LIKE '%" + txt + "%'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotContain.ToString()])
-                        filterString += "NOT LIKE '%" + txt + "%'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
+                        filterString += "NOT LIKE '%" + txt + "%'" + (_notContainingChecksNull ? " OR " + column + "IS NULL" : "");
                     break;
             }
 

--- a/AdvancedDataGridView/FormCustomFilter.cs
+++ b/AdvancedDataGridView/FormCustomFilter.cs
@@ -39,6 +39,7 @@ namespace Zuby.ADGV
         private string _filterString = null;
         private string _filterStringDescription = null;
 
+        private bool _notContainingChecksNull = false;
         #endregion
 
 
@@ -49,11 +50,13 @@ namespace Zuby.ADGV
         /// </summary>
         /// <param name="dataType"></param>
         /// <param name="filterDateAndTimeEnabled"></param>
-        public FormCustomFilter(Type dataType, bool filterDateAndTimeEnabled)
+        public FormCustomFilter(Type dataType, bool filterDateAndTimeEnabled, bool notContainingChecksNull = false)
             : base()
         {
             //initialize components
             InitializeComponent();
+
+            this._notContainingChecksNull = notContainingChecksNull;
 
             //set component translations
             this.Text = AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVFormTitle.ToString()];
@@ -318,19 +321,19 @@ namespace Zuby.ADGV
                     if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVEquals.ToString()])
                         filterString += "LIKE '" + txt + "'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotEqual.ToString()])
-                        filterString += "NOT LIKE '" + txt + "'";
+                        filterString += "NOT LIKE '" + txt + "'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVBeginsWith.ToString()])
                         filterString += "LIKE '" + txt + "%'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVEndsWith.ToString()])
                         filterString += "LIKE '%" + txt + "'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotBeginWith.ToString()])
-                        filterString += "NOT LIKE '" + txt + "%'";
+                        filterString += "NOT LIKE '" + txt + "%'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotEndWith.ToString()])
-                        filterString += "NOT LIKE '%" + txt + "'";
+                        filterString += "NOT LIKE '%" + txt + "'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVContains.ToString()])
                         filterString += "LIKE '%" + txt + "%'";
                     else if (filterTypeConditionText == AdvancedDataGridView.Translations[AdvancedDataGridView.TranslationKey.ADGVDoesNotContain.ToString()])
-                        filterString += "NOT LIKE '%" + txt + "%'";
+                        filterString += "NOT LIKE '%" + txt + "%'" + (_notContainingChecksNull ? " OR " + column + " IS NULL" : "");
                     break;
             }
 

--- a/AdvancedDataGridView/MenuStrip.cs
+++ b/AdvancedDataGridView/MenuStrip.cs
@@ -99,11 +99,11 @@ namespace Zuby.ADGV
         private Timer _textFilterTextChangedTimer;
         private int _textFilterTextChangedDelayNodes = DefaultTextFilterTextChangedDelayNodes;
         private int _textFilterTextChangedDelayMs = DefaultTextFilterTextChangedDelayMs;
-
+        private bool _notContainingChecksNull;
         #endregion
 
 
-        #region costructors
+        #region constructors
 
         /// <summary>
         /// MenuStrip constructor
@@ -375,6 +375,18 @@ namespace Zuby.ADGV
             set
             {
                 _textFilterTextChangedDelayMs = value;
+            }
+        }
+
+        public bool NotContainingChecksNull
+        {
+            get
+            {
+                return _notContainingChecksNull;
+            }
+            set
+            {
+                _notContainingChecksNull = value;
             }
         }
 
@@ -1539,7 +1551,7 @@ namespace Zuby.ADGV
                 return;
 
             //open a new Custom filter window
-            FormCustomFilter flt = new FormCustomFilter(DataType, IsFilterDateAndTimeEnabled);
+            FormCustomFilter flt = new FormCustomFilter(DataType, IsFilterDateAndTimeEnabled, NotContainingChecksNull);
 
             if (flt.ShowDialog() == DialogResult.OK)
             {


### PR DESCRIPTION
When using the Customer Filter with `DoesNotEqual`, `DoesNotBeginWith`, `DoesNotEndWith`, and `DoesNotContain` options cells which are null do not get included. From a user perspective this is unexpected.

This PR adds an optional method `AdvancedDataGridView.SetNotContainingChecksNull(DataGridViewColumn column, bool checkNulls)` to change the behaviour of those custom filter types.

For example, the following filter:
![image](https://github.com/davidegironi/advanceddatagridview/assets/31592644/c6448f88-ed50-4471-962e-23bd2120f408)

Currently produces this filter string:
`([string] NOT LIKE '%98%')`

However, the means that any null cells are not included. 

By calling `SetNotContainingChecksNull(column, true)` it will instead produce this filter string:
`([string] NOT LIKE '%98%' OR [string]  IS NULL)`

If this feature is acceptable, I could potentially add a checkbox to FormCustomFilter which allows users to specify this behaviour themselves.